### PR TITLE
Add option to enter custom topics to Google News in spaRSS (Reworked #173)

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -40,6 +40,7 @@
         <activity
             android:name=".activity.AddGoogleNewsActivity"
             android:label="@string/google_news_title"
+            android:windowSoftInputMode="stateHidden"
             android:launchMode="singleTask"/>
         <activity
             android:name=".activity.AboutActivity"

--- a/mobile/src/main/java/net/etuldan/sparss/activity/AddGoogleNewsActivity.java
+++ b/mobile/src/main/java/net/etuldan/sparss/activity/AddGoogleNewsActivity.java
@@ -25,11 +25,14 @@ import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.CheckBox;
+import android.widget.EditText;
 
 import net.etuldan.sparss.R;
 import net.etuldan.sparss.provider.FeedDataContentProvider;
 import net.etuldan.sparss.utils.UiUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.Locale;
 
 public class AddGoogleNewsActivity extends BaseActivity {
@@ -41,6 +44,7 @@ public class AddGoogleNewsActivity extends BaseActivity {
 
     private static final int[] CB_IDS = new int[]{R.id.cb_top_stories, R.id.cb_world, R.id.cb_business, R.id.cb_technology, R.id.cb_entertainment,
             R.id.cb_sports, R.id.cb_science, R.id.cb_health};
+    private EditText mCustomTopicEditText;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,6 +54,7 @@ public class AddGoogleNewsActivity extends BaseActivity {
         setResult(RESULT_CANCELED);
 
         setContentView(R.layout.activity_add_google_news);
+        mCustomTopicEditText = (EditText) findViewById(R.id.google_news_custom_topic);
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
@@ -74,6 +79,16 @@ public class AddGoogleNewsActivity extends BaseActivity {
                     url += "&topic=" + TOPIC_CODES[topic];
                 }
                 FeedDataContentProvider.addFeed(this, url, getString(TOPIC_NAME[topic]), true);
+            }
+        }
+
+        String custom_topic = mCustomTopicEditText.getText().toString();
+        if(!custom_topic.isEmpty())
+        {
+            try {
+                String url = "http://news.google.com/news?hl=" + Locale.getDefault().getLanguage() + "&output=rss&q=" + URLEncoder.encode(custom_topic, "UTF-8");
+                FeedDataContentProvider.addFeed(this, url, custom_topic, true);
+            } catch (UnsupportedEncodingException ignored) {
             }
         }
 

--- a/mobile/src/main/res/layout/activity_add_google_news.xml
+++ b/mobile/src/main/res/layout/activity_add_google_news.xml
@@ -71,6 +71,15 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/google_news_health"/>
+
+            <EditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/google_news_custom_topic"
+                android:hint="@string/google_news_custom_topic"
+                android:singleLine="true"
+                android:layout_marginTop="15dp" />
+
         </LinearLayout>
     </ScrollView>
 

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -247,4 +247,5 @@
 <string name="settings_show_new_entries">Automatisch neue Einträge anzeigen</string>
     <string name="filter_help">Filter Hilfe</string>
     <string name="settings_show_new_entries_description">Wenn deaktiviert, ist das Antippen des Buttons Neue Einträge erforderlich, um neue Einträge zu sehen</string>
-    </resources>
+    <string name="google_news_custom_topic">Eigenes Thema</string>
+</resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="google_news_sports">Sports</string>
     <string name="google_news_science">Science</string>
     <string name="google_news_health">Health</string>
+    <string name="google_news_custom_topic">Enter custom topic</string>
 
     <!-- ENTRIES -->
     <string name="all">Entries</string>


### PR DESCRIPTION
Hi!
I reworked #173 so that it can be merged automatically. Also I added @FredJul's changes to my initial pull request on Flym.

This pull request adds a EditText to the Google News section that allows custom topics.