### PR TITLE
show author even if it contains email address

### DIFF
--- a/mobile/src/main/java/net/etuldan/sparss/parser/RssAtomParser.java
+++ b/mobile/src/main/java/net/etuldan/sparss/parser/RssAtomParser.java
@@ -484,7 +484,7 @@ public class RssAtomParser extends DefaultHandler {
         } else if (TAG_NAME.equals(localName) || TAG_AUTHOR.equals(localName) || TAG_CREATOR.equals(localName)) {
             mAuthorTagEntered = false;
 
-            if (mTmpAuthor != null && mTmpAuthor.indexOf("@") == -1) { // no email
+            if (mTmpAuthor != null) {
                 if (mAuthor == null) {
                     mAuthor = new StringBuilder(mTmpAuthor);
                 } else { // this indicates multiple authors


### PR DESCRIPTION
fix for https://github.com/Etuldan/spaRSS/issues/190

not sure why email address are not wanted.
maybe a setting would be better?
