### PR TITLE
Added starred items export and reset features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.droidtitan:lint-cleaner-plugin:+'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/mobile/src/main/java/net/etuldan/sparss/fragment/EditFeedsListFragment.java
+++ b/mobile/src/main/java/net/etuldan/sparss/fragment/EditFeedsListFragment.java
@@ -81,6 +81,7 @@ import net.etuldan.sparss.activity.AddGoogleNewsActivity;
 import net.etuldan.sparss.adapter.FeedsCursorAdapter;
 import net.etuldan.sparss.parser.OPML;
 import net.etuldan.sparss.provider.FeedData.FeedColumns;
+import net.etuldan.sparss.utils.HTMLDigest;
 import net.etuldan.sparss.view.DragNDropExpandableListView;
 import net.etuldan.sparss.view.DragNDropListener;
 

--- a/mobile/src/main/java/net/etuldan/sparss/provider/FeedData.java
+++ b/mobile/src/main/java/net/etuldan/sparss/provider/FeedData.java
@@ -83,6 +83,12 @@ public class FeedData {
         return values;
     }
 
+    public static ContentValues getUnstarredContentValues() {
+        ContentValues values = new ContentValues();
+        values.putNull(EntryColumns.IS_FAVORITE);
+        return values;
+    }
+
     public static boolean shouldShowReadEntries(Uri uri) {
         boolean alwaysShowRead = EntryColumns.FAVORITES_CONTENT_URI.equals(uri) || (FeedDataContentProvider.URI_MATCHER.match(uri) == FeedDataContentProvider.URI_SEARCH);
         return alwaysShowRead || PrefUtils.getBoolean(PrefUtils.SHOW_READ, true);
@@ -190,6 +196,7 @@ public class FeedData {
         public static final String WHERE_READ = EntryColumns.IS_READ + Constants.DB_IS_TRUE;
         public static final String WHERE_UNREAD = "(" + EntryColumns.IS_READ + Constants.DB_IS_NULL + Constants.DB_OR + EntryColumns.IS_READ + Constants.DB_IS_FALSE + ')';
         public static final String WHERE_NOT_FAVORITE = "(" + EntryColumns.IS_FAVORITE + Constants.DB_IS_NULL + Constants.DB_OR + EntryColumns.IS_FAVORITE + Constants.DB_IS_FALSE + ')';
+        public static final String WHERE_FAVORITE = "(" + EntryColumns.IS_FAVORITE + Constants.DB_IS_TRUE + ')';
 
         public static Uri ENTRIES_FOR_FEED_CONTENT_URI(String feedId) {
             return Uri.parse(CONTENT_AUTHORITY + "/feeds/" + feedId + "/entries");

--- a/mobile/src/main/java/net/etuldan/sparss/utils/HTMLDigest.java
+++ b/mobile/src/main/java/net/etuldan/sparss/utils/HTMLDigest.java
@@ -1,0 +1,111 @@
+package net.etuldan.sparss.utils;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteQueryBuilder;
+import android.os.Environment;
+import android.text.TextUtils;
+import android.text.format.DateFormat;
+import android.widget.Toast;
+
+import net.etuldan.sparss.Constants;
+import net.etuldan.sparss.MainApplication;
+import net.etuldan.sparss.provider.FeedData;
+import net.etuldan.sparss.provider.FeedDataContentProvider;
+
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Date;
+
+import static net.etuldan.sparss.MainApplication.getContext;
+
+/**
+ * @author Oliver G
+ */
+
+public class HTMLDigest {
+
+    // TODO: Add timestamp to filename
+    public static final String STARRED_DIGEST = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS) + "/spaRSS_starred_digest.html";
+
+    private static final String[] FAVEXPORT_PROJECTION = new String[]{FeedData.EntryColumns.FEED_ID,
+            FeedData.EntryColumns.TITLE, FeedData.EntryColumns.DATE, FeedData.EntryColumns.LINK,
+            FeedData.EntryColumns.AUTHOR, FeedData.EntryColumns.ABSTRACT,
+            FeedData.EntryColumns.MOBILIZED_HTML};
+
+    private static final String FAVEXPORT_START = "<!DOCTYPE HTML><html>\n\t<head>\n\t\t<meta http-equiv='Content-Type' content='text/html; charset=UTF-8' />"
+                                                  + "<meta id='Viewport' name='viewport' content='initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no'>"
+                                                  + "\n\t\t<title>spaRSS favorites export</title>\n\t</head>\n\t<body>\n";
+    private static final String FAVEXPORT_ENTRY_START = "\t\t<article>\n\t\t\t<header>\n\t\t\t\t<h1>";
+    private static final String FAVEXPORT_ENTRY_AFTER_TITLE = "</h1>\n\t\t\t</header>\n\t\t\t<p><i>";
+    private static final String FAVEXPORT_ENTRY_AFTER_META = "</i>\n";
+    private static final String FAVEXPORT_ENTRY_LINK_START = "&lt;";
+    private static final String FAVEXPORT_ENTRY_LINK_END = "&gt;<br />";
+    private static final String FAVEXPORT_ENTRY_CLOSING ="</p>\n\t\t</article>\n";
+    private static final String FAVEXPORT_CLOSING = "</body>\n</html>\n";
+
+    // private static boolean mIncludeImages = false;
+
+    public static void exportStarred(String filename) throws IOException {
+
+        // Build HTML File
+        // HEADER
+        StringBuilder builder = new StringBuilder(FAVEXPORT_START);
+
+        // TODO: sort order: by Groups > by Feed > by Date
+        Cursor cursor = getContext().getContentResolver()
+            .query(FeedData.EntryColumns.FAVORITES_CONTENT_URI, FAVEXPORT_PROJECTION, null, null, FeedData.EntryColumns.DATE);
+
+        // no favorites at all? Display toast and leave!
+        if (cursor.getCount() == 0) {
+            Context context = getContext();
+            CharSequence text = "Favorites empty, nothing to export.";
+            int duration = Toast.LENGTH_SHORT;
+
+            Toast toast = Toast.makeText(context, text, duration);
+            toast.show();
+            return;
+        }
+
+        // Loop through all starred entries
+        // TODO:
+        // - Sort by Group and Feed Order Within Groups
+        // - Print Headlines with Group and Feed Names
+        while (cursor.moveToNext()) {
+            builder.append(FAVEXPORT_ENTRY_START);
+            builder.append(cursor.isNull(1) ? "" : TextUtils.htmlEncode(cursor.getString(1))); // title
+            builder.append(FAVEXPORT_ENTRY_AFTER_TITLE);
+
+            Date date = new Date(cursor.getLong(2));
+            Context context = getContext();
+            StringBuilder dateStringBuilder = new StringBuilder(DateFormat.getDateFormat(context).format(date)).append(' ').append(
+                    DateFormat.getTimeFormat(context).format(date));
+
+            builder.append(dateStringBuilder);
+
+            if (!cursor.isNull(4)) {
+                builder.append(", ");
+                builder.append(cursor.getString(4)); // author if exists
+            }
+
+            String url = cursor.getString(3);
+            builder.append("<br />").append(FAVEXPORT_ENTRY_LINK_START);
+            builder.append("<a href='").append(url).append("'>");
+            builder.append(url).append("</a>").append(FAVEXPORT_ENTRY_LINK_END);
+            builder.append(FAVEXPORT_ENTRY_AFTER_META);
+            builder.append(cursor.isNull(6) ? cursor.getString(5) : cursor.getString(6)); // fulltext unavailable? use abstract!
+            builder.append(FAVEXPORT_ENTRY_CLOSING);
+        }
+
+        // CLOSING
+        builder.append(FAVEXPORT_CLOSING);
+
+        // Write File
+        BufferedWriter writer = new BufferedWriter(new FileWriter(filename));
+
+        writer.write(builder.toString());
+        writer.close();
+    }
+}

--- a/mobile/src/main/res/menu/entry_list.xml
+++ b/mobile/src/main/res/menu/entry_list.xml
@@ -21,6 +21,14 @@
         android:title="@string/context_menu_share_starred"
         app:showAsAction="always"/>
     <item
+        android:id="@+id/menu_export_starred"
+        android:icon="@drawable/action_export"
+        android:title="@string/context_menu_export_starred" />
+    <item
+        android:id="@+id/menu_reset_starred"
+        android:icon="@drawable/action_export"
+        android:title="@string/context_menu_reset_starred" />
+    <item
         android:id="@+id/menu_all_read"
         android:icon="@drawable/ic_check"
         android:title="@string/menu_all_read"

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -60,7 +60,7 @@
     <string name="error_feed_process">Der Feed kann nicht bearbeitet werden.</string>
     <string name="error_feed_url_exists">Diese Adresse existiert schon.</string>
     <string name="error_feed_import">Die ausgewählte Datei konnte nicht importiert werden.</string>
-    <string name="error_feed_export">Der Export ist fehlgeschlagen. Stelle sicher, dass du eine beschreibbare SD-Karte verfügbar ist.</string>
+    <string name="error_feed_export">Der Export ist fehlgeschlagen. Stelle sicher, dass eine beschreibbare SD-Karte verfügbar ist.</string>
     <string name="error_external_storage_not_available">Der externe Speicher (z.B. SD-Karte) ist nicht verfügbar.</string>
     <string name="feed_url">URL</string>
     <string name="optional">(optional)</string>
@@ -114,7 +114,7 @@
     <string name="favorites">Favorisiert</string>
     <string name="context_menu_hide_read">Gelesene Einträge verstecken</string>
     <string name="context_menu_show_read">Gelesene Einträge anzeigen</string>
-    <string name="context_menu_share_starred">Favorisierte Einträge teilen</string>
+    <string name="context_menu_share_starred">Favoriten teilen</string>
     <string name="menu_star">Favorisieren</string>
     <string name="menu_unstar">Entfavorisieren</string>
     <string name="menu_share">Teilen</string>
@@ -248,6 +248,11 @@
     <string name="filter_help">Filter Hilfe</string>
     <string name="settings_show_new_entries_description">Wenn deaktiviert, ist das Antippen des Buttons Neue Einträge erforderlich, um neue Einträge zu sehen</string>
     <string name="google_news_custom_topic">Eigenes Thema</string>
-<string name="storage_request_explanation">Um Feeds aus einer Datei importieren oder in eine Datei exportieren zu können, benötigt die App Zugriffsrechte auf die SD-Karte.</string>
+<string name="storage_request_explanation">Um aus einer Datei importieren oder in eine Datei exportieren zu können, benötigt die App Zugriffsrechte auf die SD-Karte.</string>
     <string name="feed_no_summary">&lt;Keine Zusammenfassung verfügbar&gt;</string>
-    </resources>
+    <string name="context_menu_export_starred">In HTML exportieren</string>
+    <string name="context_menu_reset_starred">Favoriten zurücksetzen</string>
+    <string name="context_menu_reset_starred_confirmation">Alle Markierungen entfernen?</string>
+    <string name="confirm_negative">Nein</string>
+    <string name="confirm_positive">Ja</string>
+</resources>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -237,8 +237,13 @@
     <string name="passwordhttpAuth">Mot de passe</string>
 <string name="settings_show_new_entries_description">Si désactivé, un appui sur le bouton Afficher nouveaux articles sera requis pour les afficher</string>
     <string name="filter_help">Aide à propos des filtres</string>
-    <string name="storage_request_explanation">Pour pouvoir importer ou exporter les flux depuis ou vers un fichier, vous devez autoriser l\'application à accéder au stockage interne.</string>
+    <string name="storage_request_explanation">Pour pouvoir importer ou exporter depuis ou vers un fichier, vous devez autoriser l\'application à accéder au stockage interne.</string>
     <string name="feed_no_summary">&lt; Aucun résumé disponible. &gt;</string>
     <string name="google_news_custom_topic">Entrer un thème personnalisé</string>
+    <string name="context_menu_export_starred">Exporter vers HTML</string>
+    <string name="context_menu_reset_starred">Réinitialiser les favoris</string>
+    <string name="context_menu_reset_starred_confirmation">Éliminer tous les marques?</string>
+    <string name="confirm_negative">Non</string>
+    <string name="confirm_positive">Oui</string>
 
-    </resources>
+</resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="menu_show_new_entries">Show new entries</string>
     <string name="spaRSS_feeds">spaRSS feeds</string>
     <string name="error">Error</string>
+    <string name="confirm_positive">Yes</string>
+    <string name="confirm_negative">No</string>
     <string name="network_error">The network is not set up</string>
     <string name="loading">Loading…</string>
     <string name="no_result">No result</string>
@@ -57,7 +59,7 @@
     <string name="menu_add_group">Add group</string>
     <string name="menu_import">Import from OPML</string>
     <string name="menu_export">Export to OPML</string>
-    <string name="storage_request_explanation">To be able to import or export the feeds from or to a file, you must allow the application to access to the storage memory.</string>
+    <string name="storage_request_explanation">To be able to import or export from or to a file, you must allow the application to access to the storage memory.</string>
     <string name="error_feed_error">The feed website is unreachable.</string>
     <string name="error_feed_process">The feed can not be processed.</string>
     <string name="error_feed_url_exists">The address already exists.</string>
@@ -120,6 +122,9 @@
     <string name="context_menu_hide_read">Hide read entries</string>
     <string name="context_menu_show_read">Show read entries</string>
     <string name="context_menu_share_starred">Share starred entries</string>
+    <string name="context_menu_export_starred">Export to HTML</string>
+    <string name="context_menu_reset_starred">Reset starred list</string>
+    <string name="context_menu_reset_starred_confirmation">Remove all stars?</string>
     <string name="menu_star">Star</string>
     <string name="menu_unstar">Unstar</string>
     <string name="menu_share">Share</string>
@@ -250,5 +255,4 @@
         <item>Only over Wi-Fi</item>
         <item>Always</item>
     </string-array>
-
 </resources>


### PR DESCRIPTION
Two additional features accessible via options menu in favorites (starred items) home activity:
- basic export of all the starred items as one html digest file to downloads directory, sorted by date (menu item "export to HTML")
- reset of starred list after confirmation (menu item "reset starred list")

Very basic implementation so far, but usable.
